### PR TITLE
fix: only run release when a closed pr was actually merged

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@
 
 name: Build Unity Project
 on:
+  push:
+    branches:
+      - develop
+      - main
   pull_request:
     branches:
       - develop
@@ -40,7 +44,8 @@ jobs:
   installer-win:
     name: Build Installer for Windows
     runs-on: windows-latest
-    if: github.event.pull_request.merged == true
+    continue-on-error: true # Not necessary to merge PRs
+    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'
     needs: build-win
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build-win:
     name: Build Game for Windows
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -22,6 +23,7 @@ jobs:
 
   build-macos:
     name: Build Game for MacOS
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -36,6 +38,7 @@ jobs:
 
   installer-win:
     name: Build Installer for Windows
+    if: github.event.pull_request.merged == true
     runs-on: windows-latest
     needs: build-win
     steps:
@@ -65,6 +68,7 @@ jobs:
 
   create-release:
     name: Create Release
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     needs: [build-win, build-macos, installer-win]
     steps:


### PR DESCRIPTION
quick hotfix for the workflows introduced in #18 